### PR TITLE
Some fixes

### DIFF
--- a/bin/check_apache
+++ b/bin/check_apache
@@ -74,29 +74,34 @@ def zabbix_sender(payload, agentconfig = None, zabbixserver = None, zabbixport =
     result = 0
     err = ''
 
-    # must have a config file OR have hostname, and server name
-    if agentconfig is not None:
-        logger.debug('sending to server in agent config %s' % agentconfig)
-        sender_command = [ senderloc, '-vv', '--config', agentconfig, '--input-file', '-' ]
+    if not (os.path.exists(senderloc)) or not (os.access(senderloc, os.X_OK)):
+        logger.error("%s not exists or not executable" %(senderloc))
+        raise
+
     else:
-        if zabbixserver is not None:
-            logger.debug('sending to server %s:%s' % (zabbixserver, zabbixport))
-            sender_command = [ senderloc, '-vv', '--zabbix-server', zabbixserver, '--port', str(zabbixport), '--input-file', '-' ]
+        # must have a config file OR have hostname, and server name
+        if agentconfig is not None:
+            logger.debug('sending to server in agent config %s' % agentconfig)
+            sender_command = [ senderloc, '-vv', '--config', agentconfig, '--input-file', '-' ]
         else:
-            logger.error('must specify agent configuration or server name to call zabbix_sender with')
+            if zabbixserver is not None:
+                logger.debug('sending to server %s:%s' % (zabbixserver, zabbixport))
+                sender_command = [ senderloc, '-vv', '--zabbix-server', zabbixserver, '--port', str(zabbixport), '--input-file', '-' ]
+            else:
+                logger.error('must specify agent configuration or server name to call zabbix_sender with')
 
-    try:
-        p = Popen(sender_command, stdout = PIPE, stdin = PIPE, stderr = PIPE)
-        out, err = p.communicate( input = payload )
-        ret = p.wait()
-        result = 1
+        try:
+            p = Popen(sender_command, stdout = PIPE, stdin = PIPE, stderr = PIPE)
+            out, err = p.communicate( input = payload )
+            ret = p.wait()
+            result = 1
 
-    except Exception, e:
-      err = "%s\nFailed to execute: '%s'" % (e, " ".join(sender_command))
+        except Exception, e:
+          err = "%s\nFailed to execute: '%s'" % (e, " ".join(sender_command))
 
-    finally:
-        if ret != 0:
-          raise Exception("error returned from %s! ret: %d, out: '%s', err: '%s'" % (sender_command[0], ret, out.strip('\n'), err.strip('\n')))
+        finally:
+            if ret != 0:
+              raise Exception("error returned from %s! ret: %d, out: '%s', err: '%s'" % (sender_command[0], ret, out.strip('\n'), err.strip('\n')))
 
     return result
 
@@ -309,7 +314,7 @@ def main():
     else:
         # cron or remote check; hostname may be distinct from host running the check
         for key, val in data.items():
-            payload += "%s apache[%s,%s] %s\n" % (opts.zabbixsource, opts.host, key, val)
+            payload += "%s apache[%s] %s\n" % (opts.zabbixsource, key, val)
 
         try:
             result = zabbix_sender(


### PR DESCRIPTION
* FIX #1: Removed opts.host variable to fix the issue pointed by http://www.zabbix.org/wiki/Docs/howto/apache_monitoring_script#Method_1

* FIX #2: Check if zabbix_sender binary exists before try to use it. If not exists or if it isn't executable, the script will log the issue in syslog and raise an exception