### PR TITLE
Fix for #10 and #9

### DIFF
--- a/bin/check_apache
+++ b/bin/check_apache
@@ -149,8 +149,11 @@ def parse(data, version):
     replace = '() '
     csvobj = csv.reader(StringIO.StringIO(data), delimiter = ":", skipinitialspace = True)
     ret = {}
+    breakout = False
     for (key, val) in csvobj:
         if key == 'Scoreboard':
+            # end processing at Scorboard key
+            breakout = True
             sb = {
                 "Waiting for Connection":0,
                 "Starting up":0,
@@ -169,6 +172,8 @@ def parse(data, version):
             ret[key] = sb
         else:
             ret[key] = val
+        if breakout == True:
+       	    break
     ret2 = {}
     for (key, val) in ret.items():
         if key == "Scoreboard":


### PR DESCRIPTION
I'm no python guy so please review.

#9: https://github.com/gpmidi/zabbix-apache-stats/issues/9
#10: https://github.com/gpmidi/zabbix-apache-stats/issues/10

Apache server-status that outputs the TLSSessionCacheStatus section breaks the csv reader since that line contains no ":". 

I've added a breakout condition to end parsing the server-status after the Scorebaord status.